### PR TITLE
Added Bike Battery

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: pub
-    directory: /
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 20


### PR DESCRIPTION
Issue: https://github.com/blopker/superduper/issues/38

Just a basic bike percentage.
[<img src="https://github.com/user-attachments/assets/60d50567-146e-4710-9b63-160190c94480" alt="image" width="200"/>](https://github.com/user-attachments/assets/60d50567-146e-4710-9b63-160190c94480)

> Added a rule if battery = 0
> then it wont show, this happens on first load, but is now hidden with an if statement

 
- Gets the value and updates the State, (no need to save in db / write to bike).
- Other Changes, such as Debug mode generates a random macaddress
- Added Git Attributes, to cleanup/resolve the CR/ CRLF changes (mac/linux vs windows new line)